### PR TITLE
Add simple two-video gallery

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,9 +37,15 @@
       display:flex; flex-direction:column; align-items:center; text-align:center;
     }
 
+    .gallery{
+      width:100%; max-width:820px; display:grid;
+      grid-template-columns:repeat(auto-fit,minmax(300px,1fr));
+      gap:24px;
+    }
+
     .video-card{
-      width:100%; max-width:820px; background:var(--card);
-      border-radius:16px; padding:16px 14px 20px; margin:14px 0 18px;
+      width:100%; background:var(--card);
+      border-radius:16px; padding:16px 14px 20px;
       box-shadow:0 22px 60px rgba(255,23,68,.22), 0 6px 18px rgba(0,0,0,.45);
       border:1px solid rgba(255,255,255,.06);
     }
@@ -61,7 +67,7 @@
     /* Portada clickeable */
     .video-cover{
       position:absolute; inset:0; border:0; padding:0; cursor:pointer;
-      background:#000 url('portada.jpg?v=8') center/cover no-repeat; color:transparent;
+      background:#000 center/cover no-repeat; color:transparent;
     }
     .video-cover::after{
       content:""; position:absolute; inset:0;
@@ -79,46 +85,58 @@
       filter:drop-shadow(0 2px 6px rgba(0,0,0,.35));
     }
 
+    .coming-soon{
+      display:flex; align-items:center; justify-content:center;
+      background:url('https://picsum.photos/720/1280?blur=10') center/cover no-repeat;
+      color:var(--muted); font-family:"Playfair Display",serif; font-size:22px;
+    }
+
     footer{ margin-top:auto; font-size:12px; color:var(--muted) }
     @media (max-width:480px){ body{ padding:14px } .video-title{ font-size:19px } }
   </style>
 </head>
 <body>
-  <section class="video-card">
-    <h2 class="video-title">Set Room Sleep Token</h2>
-    <div class="ratio" id="player1">
-      <!-- Portada: al tocar se crea el reproductor -->
-      <button class="video-cover" id="cover1" aria-label="Reproducir video">
-        <span class="play-triangle" aria-hidden="true"></span>
-      </button>
-    </div>
-  </section>
+  <div class="gallery">
+    <section class="video-card">
+      <h2 class="video-title">Gethsemane</h2>
+      <div class="ratio" data-id="1anZBdJ6BfbiOCIA5OqeXTv96vidrYSCV">
+        <!-- Portada: al tocar se crea el reproductor -->
+        <button class="video-cover" aria-label="Reproducir video" style="background-image:url('portada.jpg?v=8')">
+          <span class="play-triangle" aria-hidden="true"></span>
+        </button>
+      </div>
+    </section>
+
+    <section class="video-card">
+      <h2 class="video-title">Próximamente</h2>
+      <div class="ratio coming-soon">
+        <span>Próximamente</span>
+      </div>
+    </section>
+  </div>
 
   <footer>© <span id="y"></span> Juli Turrin — Sitio simple para ver mis videos.</footer>
 
   <script>
     document.getElementById('y').textContent = new Date().getFullYear();
 
-    // Cambiá SOLO este ID si usás otro video de Drive
-    const DRIVE_ID = "1anZBdJ6BfbiOCIA5OqeXTv96vidrYSCV";
-    const driveSrc = `https://drive.google.com/file/d/${DRIVE_ID}/preview`;
+    document.querySelectorAll('.ratio[data-id]').forEach(player => {
+      const driveSrc = `https://drive.google.com/file/d/${player.dataset.id}/preview`;
+      const cover = player.querySelector('.video-cover');
 
-    const player = document.getElementById('player1');
-    const cover  = document.getElementById('cover1');
+      // Si hubiese un iframe viejo, lo quitamos
+      const old = player.querySelector('iframe'); if (old) old.remove();
 
-    // Si hubiese un iframe viejo, lo quitamos
-    const old = player.querySelector('iframe'); if (old) old.remove();
-
-    // Cargar reproductor tras interacción (mejor para móvil)
-    cover.addEventListener('click', () => {
-      const iframe = document.createElement('iframe');
-      iframe.src = driveSrc;
-      iframe.allow = "autoplay; fullscreen; picture-in-picture";
-      iframe.setAttribute('allowfullscreen', '');
-      iframe.setAttribute('referrerpolicy','strict-origin-when-cross-origin');
-      iframe.loading = "lazy";
-      player.appendChild(iframe);
-      cover.remove();
+      cover.addEventListener('click', () => {
+        const iframe = document.createElement('iframe');
+        iframe.src = driveSrc;
+        iframe.allow = "autoplay; fullscreen; picture-in-picture";
+        iframe.setAttribute('allowfullscreen', '');
+        iframe.setAttribute('referrerpolicy','strict-origin-when-cross-origin');
+        iframe.loading = "lazy";
+        player.appendChild(iframe);
+        cover.remove();
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add responsive gallery layout
- include placeholder second video
- refactor player script for multiple videos
- show blurred "Próximamente" placeholder for Gethsemane and only init players with data-id
- rename first video to "Gethsemane" and title placeholder card "Próximamente"

## Testing
- `npx -y htmlhint index.html`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6031362308324bfed6b9af69d12cb